### PR TITLE
Updated type of ko

### DIFF
--- a/src/c++/Examples/Example_SS_EA_RWG.cpp
+++ b/src/c++/Examples/Example_SS_EA_RWG.cpp
@@ -13,7 +13,7 @@
 #include "demcem_ss_ea_rwg.h"
 #include "demcem_constants.h"
 
-void demcem_ss_ea_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const double ko, const int N_theta, const int N_psi, complex<double> I_DE[] );
+void demcem_ss_ea_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const complex<double> ko, const int N_theta, const int N_psi, complex<double> I_DE[] );
 
 
 void Example_SS_EA_RWG (const int Counter_start,  const int Counter_end )

--- a/src/c++/Examples/Example_SS_EA_nxRWG.cpp
+++ b/src/c++/Examples/Example_SS_EA_nxRWG.cpp
@@ -13,7 +13,7 @@
 #include "demcem_ss_ea_rwg.h"
 #include "demcem_constants.h"
 
-void demcem_ss_ea_nxrwg (const double r1[],const double r2[],const double r3[],const double r4[], const double ko, const int N_theta, const int N_psi, complex<double> I_DE[] );
+void demcem_ss_ea_nxrwg (const double r1[],const double r2[],const double r3[],const double r4[], const complex<double> ko, const int N_theta, const int N_psi, complex<double> I_DE[] );
 
 
 void Example_SS_EA_nxRWG (const int Counter_start,  const int Counter_end)

--- a/src/c++/Examples/Example_SS_VA_RWG.cpp
+++ b/src/c++/Examples/Example_SS_VA_RWG.cpp
@@ -14,7 +14,7 @@
 #include "demcem_inline.h"
 #include "demcem_constants.h"
 
-void demcem_ss_va_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const double r5[], const double ko, const int N_theta_p, const int N_theta_q, const int N_psi, complex<double> I_DE[] );
+void demcem_ss_va_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const double r5[], const complex<double> ko, const int N_theta_p, const int N_theta_q, const int N_psi, complex<double> I_DE[] );
 
 void Example_SS_VA_RWG (const int Counter_start,  const int Counter_end )
 {

--- a/src/c++/Examples/Example_SS_VA_nxRWG.cpp
+++ b/src/c++/Examples/Example_SS_VA_nxRWG.cpp
@@ -14,7 +14,7 @@
 #include "demcem_inline.h"
 #include "demcem_constants.h"
 
-void demcem_ss_va_nxrwg (const double r1[],const double r2[],const double r3[],const double r4[], const double r5[], const double ko, const int N_theta_p, const int N_theta_q, const int N_psi, complex<double> I_DE[] );
+void demcem_ss_va_nxrwg (const double r1[],const double r2[],const double r3[],const double r4[], const double r5[], const complex<double> ko, const int N_theta_p, const int N_theta_q, const int N_psi, complex<double> I_DE[] );
 
 void Example_SS_VA_nxRWG (const int Counter_start,  const int Counter_end)
 {

--- a/src/c++/Examples/Example_WS_EA_RWG.cpp
+++ b/src/c++/Examples/Example_WS_EA_RWG.cpp
@@ -13,7 +13,7 @@
 #include "demcem_ws_ea_rwg.h"
 #include "demcem_constants.h"
 
-void demcem_ws_ea_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const double ko, const int N_theta, const int N_psi, complex<double> I_DE[] );
+void demcem_ws_ea_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const complex<double> ko, const int N_theta, const int N_psi, complex<double> I_DE[] );
 
 
 void Example_WS_EA_RWG (const int Counter_start,  const int Counter_end )

--- a/src/c++/Examples/Example_WS_ST_RWG.cpp
+++ b/src/c++/Examples/Example_WS_ST_RWG.cpp
@@ -14,7 +14,7 @@
 #include "demcem_inline.h"
 #include "demcem_constants.h"
 
-void demcem_ws_st_rwg (const double r1[],const double r2[],const double r3[], const double ko, const int Np_1D, complex<double> I_DE[] );
+void demcem_ws_st_rwg (const double r1[],const double r2[],const double r3[], const complex<double> ko, const int Np_1D, complex<double> I_DE[] );
 
 void Example_WS_ST_RWG (const int Counter_start,  const int Counter_end)
 {

--- a/src/c++/Examples/Example_WS_VA_RWG.cpp
+++ b/src/c++/Examples/Example_WS_VA_RWG.cpp
@@ -14,7 +14,7 @@
 #include "demcem_inline.h"
 #include "demcem_constants.h"
 
-void demcem_ws_va_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const double r5[], const double ko, const int N_theta_p, const int N_theta_q, const int N_psi, complex<double> I_DE[] );
+void demcem_ws_va_rwg (const double r1[],const double r2[],const double r3[],const double r4[], const double r5[], const complex<double> ko, const int N_theta_p, const int N_theta_q, const int N_psi, complex<double> I_DE[] );
 
 void Example_WS_VA_RWG (const int Counter_start,  const int Counter_end )
 {


### PR DESCRIPTION
"ko" was changed in the last merge from double to complex<double> in source files, but not in the signature of the core functions within the examples scope.